### PR TITLE
Adds test coverage for reports model

### DIFF
--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -1,2 +1,3 @@
 first_report:
   content: "This is the content of the first report"
+  accepted_by_project_owner: false

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -1,7 +1,15 @@
 require 'test_helper'
 
 class ReportTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  def test_accepted_report_scope
+    assert_equal(Report.accepted.count, 0)
+
+    report = reports(:first_report)
+    report.accepted_by_project_owner = true
+    report.save!
+
+    assert_equal(Report.accepted.count, 1)
+  end
+
 end


### PR DESCRIPTION
Just tests scope in reports model. No reason to have test coverage for associations.